### PR TITLE
Fix polluting regex leaving $ symbols for devz and socz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/pylapp/Tips-tools/compare/15.1.0...dev)
 
+### Fixed
+
+- Hotfix: polluted output results for socz and devz because of regex with $ symbol
+
 ### Changed
 
 - Add FUNDING

--- a/project/tipsntools.sh
+++ b/project/tipsntools.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Software Name: Tips'n'tools
-# SPDX-FileCopyrightText: Copyright (c) 2016-2023 Pierre-Yves Lapersonne
+# SPDX-FileCopyrightText: Copyright (c) 2016-2024 Pierre-Yves Lapersonne
 # SPDX-License-Identifier: MIT
 #
 # Author..............: Pierre-Yves Lapersonne
-# Version.............: 15.1.0
+# Version.............: 15.1.1
 # Since...............: 05/10/2016
 # Description.........: Provides some features about this update/technical watch/... project: find some elements or build HTML files from CSV files to update another file
 #
@@ -225,11 +225,11 @@ fFindInCsvFile(){
 	cat $file | while read -r line; do
 		case "$line" in
 			*$regex*)
-			if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
-				regex="s/;/\'$'\n/g"
-			else # macOS
-				regex="s/;/\n/g"
-			fi
+			#if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
+			#	regex="s/;/\'$'\n/g"
+			#else # macOS
+			regex="s/;/\n/g"
+			#fi
 			echo $line | sed $regex | while read -r item; do
 				if [ "$item" = "" ]; then
 					echo -e "\t <null>"

--- a/project/utils/core/csvToHtml_devices.sh
+++ b/project/utils/core/csvToHtml_devices.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Software Name: Tips'n'tools
-# SPDX-FileCopyrightText: Copyright (c) 2016-2023 Pierre-Yves Lapersonne
+# SPDX-FileCopyrightText: Copyright (c) 2016-2024 Pierre-Yves Lapersonne
 # SPDX-License-Identifier: MIT
 #
 # Author..............: Pierre-Yves Lapersonne
-# Version.............: 17.0.0
+# Version.............: 17.0.1
 # Since...............: 18/08/2016
 # Description.........: Process a file/an input (mainly in CSV format) to HTML with CSS if needed
 #			This file must contain several columns: Type, OS, Constructor, Name, Screen size, Sreen type, Screen resolution, SoC, GPU, Sensors, Batery, Storage, RAM, Camera, Dimensions, Weight, IP, USB Type, SD Card, SIM , UI
@@ -14,7 +14,7 @@
 #
 # ✿✿✿✿ ʕ •ᴥ•ʔ/ ︻デ═一
 
-# Debug purposses
+# Debug purposes
 #set -euxo pipefail
 set -euo pipefail
 
@@ -65,11 +65,11 @@ while read -r line; do
 		if [ $currentRowIndex -eq $(($NUMBER_OF_LINES_TO_IGNORE - 1)) ]; then
 			echo -e "\t<thead>"
 			echo -e "\t\t<tr>"
-			if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
+			#if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
 				regex="s/;/\n/g"
-			else # macOS
-				regex="s/;/\'$'\n/g"
-			fi
+			#else # macOS
+			#	regex="s/;/\'$'\n/g"
+			#fi
 			echo $line | sed $regex | while read -r item; do
 				echo -e "\t\t\t<td class=\"header\">" $item "</td>"
 			done

--- a/project/utils/core/csvToHtml_socs.sh
+++ b/project/utils/core/csvToHtml_socs.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Software Name: Tips'n'tools
-# SPDX-FileCopyrightText: Copyright (c) 2016-2023 Pierre-Yves Lapersonne
+# SPDX-FileCopyrightText: Copyright (c) 2016-2024 Pierre-Yves Lapersonne
 # SPDX-License-Identifier: MIT
 #
 # Author..............: Pierre-Yves Lapersonne
-# Version.............: 13.0.0
+# Version.............: 13.0.1
 # Since...............: 28/11/2016
 # Description.........: Process a file/an input (mainly in CSV format) to HTML with CSS if needed
 #			This file must contain several columns: Constructor, Target, Name, Gravure, Modem, Peak download speed, Peak upload speed, Bluetooth, NFC, USB, Camera support max., Video capture max., Video playback max., Display max., CPU, CPU cores number, CPU clock speed max., CPU architecture, GPU, GPU API support, AI support
@@ -14,7 +14,7 @@
 #
 # ✿✿✿✿ ʕ •ᴥ•ʔ/ ︻デ═一
 
-# Debug purposses
+# Debug purposes
 #set -euxo pipefail
 set -euo pipefail
 
@@ -65,11 +65,11 @@ while read -r line; do
 		if [ $currentRowIndex -eq $(($NUMBER_OF_LINES_TO_IGNORE - 1)) ]; then
 			echo -e "\t<thead>"
 			echo -e "\t\t<tr>"
-			if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
+			#if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
 				regex="s/;/\n/g"
-			else # macOS
-				regex="s/;/\'$'\n/g"
-			fi		
+			#else # macOS
+			#	regex="s/;/\'$'\n/g"
+			#fi		
 			echo $line | sed $regex | while read -r item; do
 				echo -e "\t\t\t<td class=\"header\">" $item "</td>"
 			done
@@ -86,11 +86,11 @@ while read -r line; do
 
 	# ***** Step 4: Split the line and replace ; by \n, and delete useless "
 	fieldIndex=0
-	if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
+	#if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
 		regex="s/;/\n/g"
-	else # macOS
-		regex="s/;/\'$'\n/g"
-	fi	
+	#else # macOS
+	#	regex="s/;/\'$'\n/g"
+	#fi	
 	echo $line | sed $regex | while read -r item; do
 		cleanItem=`echo $item | sed 's/\"//g'`
 		# Add a good CSS class

--- a/project/utils/core/csvToJson_devices.sh
+++ b/project/utils/core/csvToJson_devices.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Software Name: Tips'n'tools
-# SPDX-FileCopyrightText: Copyright (c) 2016-2023 Pierre-Yves Lapersonne
+# SPDX-FileCopyrightText: Copyright (c) 2016-2024 Pierre-Yves Lapersonne
 # SPDX-License-Identifier: MIT
 #
 # Author..............: Pierre-Yves Lapersonne
-# Version.............: 3.0.0
+# Version.............: 3.0.2
 # Since...............: 06/03/2018
 # Description.........: Process a file/an input (mainly in CSV format) to JSON
 #			This CSV file must contain several columns: Type, OS, Constructor, Name, Screen size, Sreen type, Screen resolution, SoC, GPU, Sensors, Batery, Storage, RAM, Camera, Dimensions, Weight, IP, USB Type, SD Card, SIM , UI
@@ -14,7 +14,7 @@
 #
 # ✿✿✿✿ ʕ •ᴥ•ʔ/ ︻デ═一
 
-# Debug purposses
+# Debug purposes
 #set -euxo pipefail
 set -euo pipefail
 
@@ -75,11 +75,11 @@ while read -r line; do
 
 	# ***** Step 4: Split the line and replace ; by \n, and delete useless "
 	fieldIndex=0
-	if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
+	#if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
 		regex="s/;/\n/g"
-	else # macOS
-		regex="s/;/\'$'\n/g"
-	fi
+	#else # macOS
+	#	regex="s/;/\'$'\n/g"
+	#fi
 	echo $line | sed $regex | while read -r item; do
 		cleanItem=`echo $item | sed 's/\"//g'`
 		# Update entry

--- a/project/utils/core/csvToJson_socs.sh
+++ b/project/utils/core/csvToJson_socs.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 #
 # Author..............: Pierre-Yves Lapersonne
-# Version.............: 3.0.0
+# Version.............: 3.0.2
 # Since...............: 06/03/2018
 # Description.........: Process a file/an input (mainly in CSV format) to JSON
 #			This file must contain several columns: Constructor, Target, Name, Gravure, Modem, Peak download speed, Peak upload speed, Bluetooth, NFC, USB, Camera support max., Video capture max., Video playback max., Display max., CPU, CPU cores number, CPU clock speed max., CPU architecture, GPU, GPU API support, AI support
@@ -14,7 +14,7 @@
 #
 # ✿✿✿✿ ʕ •ᴥ•ʔ/ ︻デ═一
 
-# Debug purposses
+# Debug purposes
 #set -euxo pipefail
 set -euo pipefail
 
@@ -75,11 +75,11 @@ while read -r line; do
 
 	# ***** Step 4: Split the line and replace ; by \n, and delete useless "
 	fieldIndex=0
-	if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
+	#if [ $(DoesRunOnGNULinux) == "yes" ]; then # GNU/Linux
 		regex="s/;/\n/g"
-	else # macOS
-		regex="s/;/\'$'\n/g"
-	fi	
+	#else # macOS
+	#	regex="s/;/\'$'\n/g"
+	#fi	
 	echo $line | sed $regex | while read -r item; do
 		cleanItem=`echo $item | sed 's/\"//g'`
 		# Update entry


### PR DESCRIPTION
Note this is an hotfix with only commented lines ; it may imply same types of regressions for GNU/Linux OS as the fix was on regex to apply to clean results.